### PR TITLE
Fixes MiddleWareFunction type

### DIFF
--- a/packages/remix-create-express-app/README.md
+++ b/packages/remix-create-express-app/README.md
@@ -241,7 +241,9 @@ export type MiddlewareFunctionArgs = {
   next: () => Promise<Response>
 }
 
-export type MiddleWareFunction = (args: MiddlewareFunctionArgs) => Response
+export type MiddleWareFunction = (
+  args: MiddlewareFunctionArgs,
+) => Response | Promise<Response>
 ```
 
 You can have multiple middleware functions for a given route. In your route, export the

--- a/packages/remix-create-express-app/src/middleware.ts
+++ b/packages/remix-create-express-app/src/middleware.ts
@@ -22,7 +22,9 @@ export type MiddlewareFunctionArgs = {
   next: () => Promise<Response>
 }
 
-export type MiddleWareFunction = (args: MiddlewareFunctionArgs) => Response
+export type MiddleWareFunction = (
+  args: MiddlewareFunctionArgs,
+) => Response | Promise<Response>
 
 export type Middleware = MiddleWareFunction[]
 


### PR DESCRIPTION
Given that [middleware is awaited](https://github.com/kiliman/remix-express-vite-plugin/blob/main/packages/remix-create-express-app/src/middleware.ts#L131), I believe this is the correct typing for middleware functions.

I chose not to introduce a breaking change by applying consistent casing to `MiddleWareFunction` => `MiddlewareFunction`, but happy to revise/add an alias if desired.