### PR TITLE
Add buildDirectory and serverBuildFile as options to CreateExpressApp

### DIFF
--- a/packages/remix-create-express-app/README.md
+++ b/packages/remix-create-express-app/README.md
@@ -67,6 +67,12 @@ export type CreateExpressAppArgs = {
 
   // set to true to use unstable middleware
   unstable_middleware?: boolean
+
+  // remix build directory as defined in vite.config https://remix.run/docs/en/main/file-conventions/vite-config#builddirectory
+  buildDirectory?: string
+  
+  // sever build file as defined in vite.config https://remix.run/docs/en/main/file-conventions/vite-config#serverbuildfile
+  serverBuildFile?: string
 }
 ```
 


### PR DESCRIPTION
Fixes #20 

Adds `buildDirectory` and `serverBuildFile` as options to `createExpressApp`
Allows an application to have a custom build directory and server entry point file name as defined in the remix vite config