### PR TITLE
(ISSUE-16) Move minimatch to a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12083,12 +12083,14 @@
       }
     },
     "packages/remix-express-dev-server": {
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "ISC",
+      "dependencies": {
+        "minimatch": "^9.0.4"
+      },
       "devDependencies": {
         "@remix-run/dev": "^2.9.1",
         "esbuild": "^0.20.2",
-        "minimatch": "^9.0.4",
         "prettier": "^3.2.5",
         "typescript": "^5.4.5",
         "vite": "^5.2.10"
@@ -12096,7 +12098,6 @@
       "peerDependencies": {
         "@remix-run/dev": "^2.8.1",
         "esbuild": "^0.20.2",
-        "minimatch": "^9.0.4",
         "vite": "^5.2.8"
       }
     },
@@ -13475,7 +13476,6 @@
     },
     "packages/remix-express-dev-server/node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "packages/remix-express-dev-server/node_modules/base64-js": {
@@ -13556,7 +13556,6 @@
     },
     "packages/remix-express-dev-server/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -16313,7 +16312,6 @@
     },
     "packages/remix-express-dev-server/node_modules/minimatch": {
       "version": "9.0.4",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"

--- a/packages/remix-express-dev-server/package.json
+++ b/packages/remix-express-dev-server/package.json
@@ -20,10 +20,12 @@
   },
   "author": "",
   "license": "ISC",
+  "dependencies": {
+    "minimatch": "^9.0.4"
+  },
   "devDependencies": {
     "@remix-run/dev": "^2.9.1",
     "esbuild": "^0.20.2",
-    "minimatch": "^9.0.4",
     "prettier": "^3.2.5",
     "typescript": "^5.4.5",
     "vite": "^5.2.10"
@@ -31,7 +33,6 @@
   "peerDependencies": {
     "@remix-run/dev": "^2.8.1",
     "esbuild": "^0.20.2",
-    "minimatch": "^9.0.4",
     "vite": "^5.2.8"
   }
 }


### PR DESCRIPTION
Fixes #16 
Removed minimatch as a peerDep and added to the project dependencies