### PR TITLE
(ISSUE-24) Entry point loaded twice

### DIFF
--- a/packages/remix-express-dev-server/src/index.ts
+++ b/packages/remix-express-dev-server/src/index.ts
@@ -66,16 +66,22 @@ export function expressDevServer(options?: DevServerOptions): VitePlugin {
             }
           }
 
-          let build
+          let module
 
           try {
-            build = await server.ssrLoadModule(entry)
+            module = await server.moduleGraph.getModuleByUrl(entry);
           } catch (e) {
             return next(e)
           }
 
+          const entryModule = module?.ssrModule?.entry.module;
+
+          if (entryModule === undefined) {
+            return next();
+          }
+
           // explicitly typed since express handle function is not exported
-          const app = build.entry.module[exportName] as {
+          const app = entryModule[exportName] as {
             handle: (
               req: http.IncomingMessage,
               res: http.ServerResponse,


### PR DESCRIPTION
Fixes #24 Work in progress, for discussion.

Use `server.moduleGraph.getModuleByUrl` to load the remix entry point module.

From my testing using ssrLoadModule will cause the `entry.server` file to be loaded and transformed twice.
The first time this module loads is by the remix plugin, and the again in this plugin.

Using the moduleGraph API we can retrieve a module from the cache without reloading it.