### PR TITLE
Opportunity to set base

### DIFF
--- a/packages/remix-create-express-app/README.md
+++ b/packages/remix-create-express-app/README.md
@@ -79,6 +79,10 @@ export type CreateExpressAppArgs = {
 
   // sever build file as defined in vite.config https://remix.run/docs/en/main/file-conventions/vite-config#serverbuildfile
   serverBuildFile?: string
+
+  // base as defined in vite.config https://vite.dev/config/shared-options.html#base, but without a trailing slash (/).
+  // Let it empty if you use the default base
+  basePath?: string
 }
 ```
 

--- a/packages/remix-create-express-app/src/index.ts
+++ b/packages/remix-create-express-app/src/index.ts
@@ -37,6 +37,7 @@ export type CreateExpressAppArgs = {
   unstable_middleware?: boolean
   buildDirectory?: string
   serverBuildFile?: string
+  basePath?: string
 }
 
 export async function createExpressApp({
@@ -48,6 +49,7 @@ export async function createExpressApp({
   unstable_middleware,
   buildDirectory = 'build',
   serverBuildFile = 'index.js',
+  basePath = ""
 }: CreateExpressAppArgs = {}): Promise<Application> {
   sourceMapSupport.install({
     retrieveSourceMap: function (source) {
@@ -88,7 +90,7 @@ export async function createExpressApp({
 
   // Vite fingerprints its assets so we can cache forever.
   app.use(
-    '/assets',
+    `${basePath}/assets`,
     express.static(`${buildDirectory}/client/assets`, {
       immutable: true,
       maxAge: '1y',
@@ -98,6 +100,7 @@ export async function createExpressApp({
   // Everything else (like favicon.ico) is cached for an hour. You may want to be
   // more aggressive with this caching.
   app.use(
+    `${basePath}`,
     express.static(isProductionMode ? `${buildDirectory}/client` : 'public', {
       maxAge: '1h',
     }),

--- a/packages/remix-express-dev-server/README.md
+++ b/packages/remix-express-dev-server/README.md
@@ -44,6 +44,7 @@ export type DevServerOptions = {
   entry?: string // Express app entry: default = 'virtual:remix/server-build'
   entryName?: string // name of express app export: default = app
   appDirectory?: string // path to remix app directory: default = ./app
+  base?: string // base of your app without a trailing slash: default = '' (empty string)
   configureServer?: (server: http.Server) => void // allow additional configuration
   // of Vite dev server (like setting up socket.io)
 }

--- a/packages/remix-express-dev-server/src/index.ts
+++ b/packages/remix-express-dev-server/src/index.ts
@@ -58,8 +58,8 @@ export function expressDevServer(options?: DevServerOptions): VitePlugin {
         ): Promise<void> {
           // exclude requests that should be handled by Vite dev server
           const exclude = [
-            new RegExp(`^${basePattern}\/@.+$`),
-            new RegExp(`^${basePattern}\/node_modules\\/.*`)
+            new RegExp(`^${basePattern}/@.+$`),
+            new RegExp(`^${basePattern}/node_modules/.*`)
           ]
 
           for (const pattern of exclude) {

--- a/packages/remix-express-dev-server/src/index.ts
+++ b/packages/remix-express-dev-server/src/index.ts
@@ -7,6 +7,7 @@ export type DevServerOptions = {
   entry?: string
   exportName?: string
   appDirectory?: string
+  base?: string
   configureServer?: (server: http.Server) => void
 }
 
@@ -14,6 +15,7 @@ export const defaultOptions: Required<DevServerOptions> = {
   entry: 'virtual:remix/server-build',
   exportName: 'app',
   appDirectory: './app',
+  base: "",
   configureServer: () => {},
 }
 
@@ -31,11 +33,13 @@ export function expressDevServer(options?: DevServerOptions): VitePlugin {
   const exportName = options?.exportName ?? defaultOptions.exportName
   const configureServer =
     options?.configureServer ?? defaultOptions.configureServer
-  let appDirectory = normalizeAppDirectory(
+  const appDirectory = normalizeAppDirectory(
     options?.appDirectory ?? defaultOptions.appDirectory,
   )
+  const base = options?.base ?? defaultOptions.base
 
-  const appDirectoryPattern = new RegExp(`^${escapeRegExp(appDirectory)}`)
+  const basePattern = escapeRegExp(base);
+  const appDirectoryPattern = new RegExp(`^${basePattern}${escapeRegExp(appDirectory)}`)
 
   const plugin: VitePlugin = {
     name: 'remix-express-dev-server',
@@ -53,7 +57,10 @@ export function expressDevServer(options?: DevServerOptions): VitePlugin {
           next: Connect.NextFunction,
         ): Promise<void> {
           // exclude requests that should be handled by Vite dev server
-          const exclude = [/^\/@.+$/, /^\/node_modules\/.*/]
+          const exclude = [
+            new RegExp(`^${basePattern}\/@.+$`),
+            new RegExp(`^${basePattern}\/node_modules\\/.*`)
+          ]
 
           for (const pattern of exclude) {
             if (req.url) {
@@ -69,7 +76,7 @@ export function expressDevServer(options?: DevServerOptions): VitePlugin {
           // check if url is a physical file in the app directory
           if (appDirectoryPattern.test(req.url!)) {
             const url = new URL(req.url!, 'http://localhost')
-            if (fs.existsSync(url.pathname.slice(1))) {
+            if (fs.existsSync(url.pathname.replace(base, "").slice(1))) {
               return next()
             }
           }


### PR DESCRIPTION
I have a setup where I need to have base/baseName for Vite/Remix. expressDevServer doesn't really support such setup. So I think I have fixed it. In addition createExpressApp should have basePath for assets and other static files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `base` property for configuring a base URL in the server options.
	- Added an optional `basePath` property for specifying a base path in the application setup.

- **Improvements**
	- Enhanced URL matching and file path resolution with the new base URL and base path configurations.
	- Updated static asset paths to incorporate the new `basePath`, allowing for more flexible URL structures.

- **Documentation**
	- Updated README files to include new configuration options and examples for middleware usage and integration with the Vite dev server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->